### PR TITLE
Call postinstall hook to perform setup of autocomplete after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "url": "git@github.com:cob/cob-cli.git"
   },
   "main": "./bin/cob-cli.js",
+  "scripts": {
+    "postinstall": "bin/cob-cli.js --setup",
+    "uninstall": "bin/cob-cli.js --cleanup"
+  },
   "bin": {
     "cob-cli": "bin/cob-cli.js"
   },


### PR DESCRIPTION
According to the documentation of [omelette](https://github.com/f/omelette#automated-install) it is necessary to call the `completion.setupShellInitFile()` to make the autocomplete feature available. (Maybe because I have zshell it is necessary).

To achieve this during the installation we need to setup an install hook `postinstall` script that will run a script after install is finished and that will call `cob-cli --setup` to setup autocomplete.

References:
* npm hooks https://docs.npmjs.com/cli/v8/using-npm/scripts
* https://github.com/f/omelette#automated-install

