### PR TITLE
Fixes cob-cli not detecting changes on OS with rsync versions 3.*.*

### DIFF
--- a/lib/task_lists/common_syncFiles.js
+++ b/lib/task_lists/common_syncFiles.js
@@ -121,7 +121,7 @@ function _formatRsyncOutput(product, rsyncOutput) {
         .slice(1, -3) // O Header e o Footer não interessam
         .filter(line => /^[*<>]/.test(line)) // Só interessam linhas de mudança (ie, * ou > ou < )
         .map(line => {
-            let linePart = line.split(" ");
+            let linePart = line.split(/\s+/);
             if (linePart[0] == "*deleting")
                 return "delete".brightRed + " " + product + "/" + linePart[1];
             if (linePart[0].startsWith("<fc"))


### PR DESCRIPTION
On the file `lib/task_lists/common_syncFiles.js` line 124,  replaces `let linePart = line.split(" ");` by
 `let linePart = line.split(/\s+/);`. This change is to split the line by multiple white spaces sequences.
