### PR TITLE
Add the `search space` option for cob-cli customize

### DIFF
--- a/bin/cob-cli.js
+++ b/bin/cob-cli.js
@@ -46,6 +46,7 @@ program
 program
     .command('customize')
     .arguments('[name]', "Name to filter the list of customizations", "interactive menu")
+    .option('-s --space <space>', 'specifies search space, default is org:cob') 
     .option('-f --force', 'skips comparisons')
     .option('-c --cache', 'cache all customizations')
     .option('-l --local', 'use local files')

--- a/lib/commands/customize.js
+++ b/lib/commands/customize.js
@@ -56,7 +56,8 @@ async function getCustomizationsList(filter, args) {
     }
   } else {
     // Get list of relevant customizations from github
-    const response = await axios.get( "https://api.github.com/search/repositories?q=" + customizationNameQuery + "+in:name+org:cob", { headers: { Accept: "application/json", "Accept-Encoding": "identity" } } )
+    const space = args.space ? args.space : "org:cob"
+    const response = await axios.get( "https://api.github.com/search/repositories?q=" + customizationNameQuery + "+in:name+" + space, { headers: { Accept: "application/json", "Accept-Encoding": "identity" } } )
     customizationRepos = response.data.items
   }
 


### PR DESCRIPTION
Added the option -s <space> that allows the user to select where to search for customizations. By default it is "org:cob". It uses the github search syntax and essentially supports 

org:<orgname>
user:<username>

The goal is to allow us to have customizations in different places other than the cob organization, while not changing the workflow we are accustomed to. 

There is no syntax verification for the space purposefully - if it is wrong, GitHub simply won't return any results. 