### PR TITLE
não força o grupo do ficheiro sincronizado quando se faz um cob-cli test

### DIFF
--- a/lib/task_lists/test_syncFile.js
+++ b/lib/task_lists/test_syncFile.js
@@ -24,6 +24,7 @@ async function syncFile(server, localFile) {
             "--prune-empty-dirs",
             "--chmod=Fg+w",
             "--no-perms",
+            "--no-group",
             "--no-t",
             "--filter='merge " + path.resolve(__dirname,"rsyncFilter-pre.txt") + "'",
             "--filter='merge " + path.resolve(__dirname,"rsyncFilter-post.txt") + "'"],


### PR DESCRIPTION
fix igual ao que se fez para o deploy "stop trying chgrp on deploys"

Isto estava a mudar o grupo ownwer dos ficheiros que se mexiam num cob-cli test e, no caso da vodafone, metia os ficheiros com um owner que nem o cob acedia