### PR TITLE
feat: add cleanup command to reset repo after interrupted test/deploy

### DIFF
--- a/bin/cob-cli.js
+++ b/bin/cob-cli.js
@@ -10,6 +10,7 @@ const init             = require("../lib/commands/init");
 const customize        = require("../lib/commands/customize");
 const test             = require("../lib/commands/test");
 const deploy           = require("../lib/commands/deploy");
+const cleanup          = require("../lib/commands/cleanup");
 const updateFromServer = require("../lib/commands/updateFromServer");
 const getDefs          = require("../lib/commands/getDefs");
 const generateMermaid  = require("../lib/commands/generateMermaid");
@@ -72,6 +73,15 @@ program
     .option('-s --servername <servername>', 'use <servername>.cultofbits.pt (i.e. name without the FQDN)')
     .description('Deploy customization to the server')
     .action( deploy );
+
+program
+    .command('cleanup')
+    .option('-e --environment <name>', 'environment to use')
+    .option('-s --servername <servername>', 'use <servername>.cultofbits.pt (i.e. name without the FQDN)')
+    .option('-l --localOnly', 'only clean local state, skip server cleanup')
+    .option('-V --verbose', 'verbose execution of tasks', increaseVerbosity, 0)
+    .description('Clean up repository state after an interrupted test or deploy')
+    .action( cleanup );
 
 program
     .command('updateFromServer')

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -8,6 +8,8 @@ const UpdaterRenderer = require('listr-update-renderer');
 const verboseRenderer = require('listr-verbose-renderer');
 const { getCurrentCommandEnviroment } = require("../task_lists/common_enviromentHandler");
 const { SERVER_COB_CLI_DIRECTORY } = require("../task_lists/common_helpers");
+const { getLastDeployedSha } = require("../task_lists/common_releaseManager");
+const { syncFile } = require("../task_lists/test_syncFile");
 const { loadOperationState, clearOperationState } = require("../task_lists/common_operationState");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
 
@@ -30,6 +32,55 @@ async function cleanup(args) {
         console.log(`  environment: ${cmdEnv.name.bold}  server: ${cmdEnv.serverStr}`)
 
         await new Listr([
+            {
+                // Must run before "Undo env changes": stashes any env-swapped files,
+                // checks out last-deployed versions, pushes them to server, then pops
+                // the stash — mirroring the restoreChanges() + unApply order in test.js.
+                title: "Restore server files to last deployed version".bold,
+                skip: () => args.localOnly ? "Skipping server restore (--localOnly)" : false,
+                task: async () => {
+                    let changedFiles = [];
+                    try {
+                        const result = await execa('ssh', [cmdEnv.server, "cat " + SERVER_TEST_LOCK_FILE]);
+                        changedFiles = result.stdout.split("\n")
+                            .map(l => l.split(" ")[0].trim())
+                            .filter(f => f);
+                    } catch { /* no test.in.execution on server = nothing to restore */ }
+
+                    if (changedFiles.length === 0) return;
+
+                    console.log("\n  Restoring changed files...".yellow);
+
+                    let stashed = false;
+                    await git().env('LC_ALL', 'C').stash(["--include-untracked"])
+                        .then(value => { stashed = value.indexOf("Saved") === 0; })
+                        .catch(() => {});
+
+                    const lastSha = await getLastDeployedSha(cmdEnv.server);
+                    if (!lastSha) throw new Error("Cannot restore server files: no previous deploy found on server.");
+                    await git().checkout(lastSha);
+
+                    await cmdEnv.applyLastEnvironmentDeployedToServerChanges();
+
+                    for (const changedFile of changedFiles) {
+                        await syncFile(cmdEnv.server, changedFile);
+                        await execa('ssh', [cmdEnv.server,
+                            "sed -i '/" + changedFile.split("/").join("\\/") + "/d' " + SERVER_TEST_LOCK_FILE
+                        ]).catch(() => {});
+                        console.log("  reset ".brightGreen + changedFile);
+                    }
+
+                    await cmdEnv.unApplyLastEnvironmentDeployedToServerChanges();
+
+                    // Remove server lock file if now empty
+                    await execa('ssh', [cmdEnv.server,
+                        "find " + SERVER_TEST_LOCK_FILE + " -size 0 -delete"
+                    ]).catch(() => {});
+
+                    await git().checkout("-");
+                    if (stashed) await git().stash(["pop"]);
+                }
+            },
             {
                 title: "Undo environment-specific file changes".bold,
                 skip: async () => {
@@ -57,9 +108,8 @@ async function cleanup(args) {
             {
                 title: "Remove server test lock file".bold,
                 skip: () => args.localOnly ? "Skipping server cleanup (--localOnly)" : false,
-                task: (ctx) => execa('ssh', [cmdEnv.server, "rm -f " + SERVER_TEST_LOCK_FILE])
-                    .then(() => { ctx.serverCleaned = true; })
-                    .catch(() => { ctx.serverUnreachable = true; })
+                task: () => execa('ssh', [cmdEnv.server, "rm -f " + SERVER_TEST_LOCK_FILE])
+                    .catch(() => {}) // non-critical if server unreachable
             },
         ], {
             renderer: args.verbose ? verboseRenderer : UpdaterRenderer,
@@ -77,8 +127,7 @@ async function cleanup(args) {
             console.log("Run " + "git stash pop".yellow + " if you want to restore your uncommitted changes.\n")
         }
 
-        console.log("\nDone!".green, "\nYou can now run 'cob-cli test' or 'cob-cli deploy' again.")
-        console.log("If files were changed during a test, a " + "cob-cli deploy -f".yellow + " with the previous version may be needed to resync.\n")
+        console.log("\nDone!".green, "\nYou can now run 'cob-cli test' or 'cob-cli deploy' again.\n")
 
     } catch(err) {
         console.error("\n", err.message)

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -1,0 +1,77 @@
+require('colors');
+const git = require('simple-git');
+const fs = require('fs-extra');
+const fg = require('fast-glob');
+const execa = require('execa');
+const Listr = require('listr');
+const UpdaterRenderer = require('listr-update-renderer');
+const verboseRenderer = require('listr-verbose-renderer');
+const { getCurrentCommandEnviroment } = require("../task_lists/common_enviromentHandler");
+const { SERVER_COB_CLI_DIRECTORY } = require("../task_lists/common_helpers");
+const { checkRepoVersion } = require("../commands/upgradeRepo");
+
+const LOCAL_TEST_LOCK_FILE = ".test.in.execution";
+const SERVER_TEST_LOCK_FILE = SERVER_COB_CLI_DIRECTORY + "test.in.execution";
+
+async function cleanup(args) {
+    try {
+        checkRepoVersion()
+        console.log("Cleaning up interrupted test/deploy state...".bold)
+
+        const cmdEnv = await getCurrentCommandEnviroment(args)
+
+        await new Listr([
+            {
+                title: "Undo environment-specific file changes".bold,
+                skip: async () => {
+                    const backupFiles = await fg(
+                        ['**/*.ENV__ORIGINAL_BACKUP__.*', '**/*.ENV__DELETE__.*'],
+                        { onlyFiles: false, dot: true }
+                    );
+                    return backupFiles.length === 0 ? "No environment-specific changes found" : false;
+                },
+                task: () => cmdEnv.unApplyCurrentCommandEnvironmentChanges()
+            },
+            {
+                title: "Restore git branch from detached HEAD".bold,
+                skip: async () => {
+                    const branch = await git().revparse(["--abbrev-ref", "HEAD"]);
+                    return branch.trim() !== "HEAD" ? "Not in detached HEAD state" : false;
+                },
+                task: () => git().checkout("-")
+            },
+            {
+                title: "Remove local test lock file".bold,
+                skip: () => !fs.existsSync(LOCAL_TEST_LOCK_FILE) ? "No local test lock file found" : false,
+                task: () => fs.unlinkSync(LOCAL_TEST_LOCK_FILE)
+            },
+            {
+                title: "Remove server test lock file".bold,
+                skip: () => args.localOnly ? "Skipping server cleanup (--localOnly)" : false,
+                task: (ctx) => execa('ssh', [cmdEnv.server, "rm -f " + SERVER_TEST_LOCK_FILE])
+                    .then(() => { ctx.serverCleaned = true; })
+                    .catch(() => { ctx.serverUnreachable = true; })
+            },
+        ], {
+            renderer: args.verbose ? verboseRenderer : UpdaterRenderer,
+            collapse: false
+        }).run()
+
+        // Inform about stashes — don't auto-pop since user may have unrelated stashes
+        const stashList = await git().stash(["list"]);
+        if (stashList) {
+            console.log("\n" + "Note:".yellow.bold
+                + " Stashed changes detected (may be from the interrupted operation):")
+            console.log(stashList.split("\n").slice(0, 3).map(l => "  " + l).join("\n"))
+            console.log("Run " + "git stash pop".yellow + " if you want to restore your uncommitted changes.\n")
+        }
+
+        console.log("\nDone!".green, "\nYou can now run 'cob-cli test' or 'cob-cli deploy' again.")
+        console.log("If files were changed during a test, run " + "cob-cli updateFromServer".yellow + " to resync.\n")
+
+    } catch(err) {
+        console.error("\n", err.message)
+    }
+}
+
+module.exports = cleanup;

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -8,8 +8,7 @@ const UpdaterRenderer = require('listr-update-renderer');
 const verboseRenderer = require('listr-verbose-renderer');
 const { getCurrentCommandEnviroment } = require("../task_lists/common_enviromentHandler");
 const { SERVER_COB_CLI_DIRECTORY } = require("../task_lists/common_helpers");
-const { getLastDeployedSha } = require("../task_lists/common_releaseManager");
-const { removeFileFromCurrentTest } = require("../task_lists/test_otherFilesContiousReload");
+const { restoreServerFilesToLastDeployed } = require("../task_lists/test_otherFilesContiousReload");
 const { loadOperationState, clearOperationState } = require("../task_lists/common_operationState");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
 
@@ -59,32 +58,7 @@ async function cleanup(args) {
 
                     if (changedFiles.length === 0) return;
 
-                    console.log("\n  Restoring changed files...".yellow);
-
-                    let stashed = false;
-                    await git().env('LC_ALL', 'C').stash(["--include-untracked"])
-                        .then(value => { stashed = value.indexOf("Saved") === 0; })
-                        .catch(() => {});
-
-                    const lastSha = await getLastDeployedSha(cmdEnv.server);
-                    if (!lastSha) throw new Error("Cannot restore server files: no previous deploy found on server.");
-                    await git().checkout(lastSha);
-
-                    await cmdEnv.applyLastEnvironmentDeployedToServerChanges();
-
-                    for (const changedFile of changedFiles) {
-                        await removeFileFromCurrentTest(cmdEnv.server, changedFile);
-                    }
-
-                    await cmdEnv.unApplyLastEnvironmentDeployedToServerChanges();
-
-                    // Remove server lock file if now empty
-                    await execa('ssh', [cmdEnv.server,
-                        "find " + SERVER_TEST_LOCK_FILE + " -size 0 -delete"
-                    ]).catch(() => {});
-
-                    await git().checkout("-");
-                    if (stashed) await git().stash(["pop"]);
+                    await restoreServerFilesToLastDeployed(cmdEnv, changedFiles);
                 }
             },
             {

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -33,9 +33,19 @@ async function cleanup(args) {
 
         await new Listr([
             {
-                // Undoes any pending env swap first so git can see all files clearly,
-                // then stashes, checks out last-deployed versions, pushes them to server,
-                // and restores git state. The "Undo env" task below becomes a no-op.
+                title: "Undo environment-specific file changes".bold,
+                skip: async () => {
+                    const backupFiles = await fg(
+                        ['**/*.ENV__ORIGINAL_BACKUP__.*', '**/*.ENV__DELETE__.*'],
+                        { onlyFiles: false, dot: true }
+                    );
+                    return backupFiles.length === 0 ? "No environment-specific changes found" : false;
+                },
+                task: () => cmdEnv.unApplyCurrentCommandEnvironmentChanges()
+            },
+            {
+                // Runs after the local env undo so the working tree is clean before
+                // stashing and checking out the last-deployed SHA.
                 title: "Restore server files to last deployed version".bold,
                 skip: () => args.localOnly ? "Skipping server restore (--localOnly)" : false,
                 task: async () => {
@@ -50,11 +60,6 @@ async function cleanup(args) {
                     if (changedFiles.length === 0) return;
 
                     console.log("\n  Restoring changed files...".yellow);
-
-                    // Undo any pending env swap first so git can properly see all files
-                    // before stashing. Files marked --assume-unchanged are invisible to
-                    // git stash, which would leave them on disk and cause checkout to fail.
-                    await cmdEnv.unApplyCurrentCommandEnvironmentChanges();
 
                     let stashed = false;
                     await git().env('LC_ALL', 'C').stash(["--include-untracked"])
@@ -85,17 +90,6 @@ async function cleanup(args) {
                     await git().checkout("-");
                     if (stashed) await git().stash(["pop"]);
                 }
-            },
-            {
-                title: "Undo environment-specific file changes".bold,
-                skip: async () => {
-                    const backupFiles = await fg(
-                        ['**/*.ENV__ORIGINAL_BACKUP__.*', '**/*.ENV__DELETE__.*'],
-                        { onlyFiles: false, dot: true }
-                    );
-                    return backupFiles.length === 0 ? "No environment-specific changes found" : false;
-                },
-                task: () => cmdEnv.unApplyCurrentCommandEnvironmentChanges()
             },
             {
                 title: "Restore git branch from detached HEAD".bold,

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -8,6 +8,7 @@ const UpdaterRenderer = require('listr-update-renderer');
 const verboseRenderer = require('listr-verbose-renderer');
 const { getCurrentCommandEnviroment } = require("../task_lists/common_enviromentHandler");
 const { SERVER_COB_CLI_DIRECTORY } = require("../task_lists/common_helpers");
+const { loadOperationState, clearOperationState } = require("../task_lists/common_operationState");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
 
 const LOCAL_TEST_LOCK_FILE = ".test.in.execution";
@@ -16,6 +17,13 @@ const SERVER_TEST_LOCK_FILE = SERVER_COB_CLI_DIRECTORY + "test.in.execution";
 async function cleanup(args) {
     try {
         checkRepoVersion()
+
+        const savedState = loadOperationState();
+        if (savedState) {
+            if (!args.environment) args.environment = savedState.environment;
+            if (!args.servername)  args.servername  = savedState.servername;
+        }
+
         console.log("Cleaning up interrupted test/deploy state...".bold)
 
         const cmdEnv = await getCurrentCommandEnviroment(args)
@@ -56,6 +64,8 @@ async function cleanup(args) {
             renderer: args.verbose ? verboseRenderer : UpdaterRenderer,
             collapse: false
         }).run()
+
+        clearOperationState()
 
         // Inform about stashes — don't auto-pop since user may have unrelated stashes
         const stashList = await git().stash(["list"]);

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -9,7 +9,7 @@ const verboseRenderer = require('listr-verbose-renderer');
 const { getCurrentCommandEnviroment } = require("../task_lists/common_enviromentHandler");
 const { SERVER_COB_CLI_DIRECTORY } = require("../task_lists/common_helpers");
 const { getLastDeployedSha } = require("../task_lists/common_releaseManager");
-const { syncFile } = require("../task_lists/test_syncFile");
+const { removeFileFromCurrentTest } = require("../task_lists/test_otherFilesContiousReload");
 const { loadOperationState, clearOperationState } = require("../task_lists/common_operationState");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
 
@@ -73,11 +73,7 @@ async function cleanup(args) {
                     await cmdEnv.applyLastEnvironmentDeployedToServerChanges();
 
                     for (const changedFile of changedFiles) {
-                        await syncFile(cmdEnv.server, changedFile);
-                        await execa('ssh', [cmdEnv.server,
-                            "sed -i '/" + changedFile.split("/").join("\\/") + "/d' " + SERVER_TEST_LOCK_FILE
-                        ]).catch(() => {});
-                        console.log("  reset ".brightGreen + changedFile);
+                        await removeFileFromCurrentTest(cmdEnv.server, changedFile);
                     }
 
                     await cmdEnv.unApplyLastEnvironmentDeployedToServerChanges();

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -27,6 +27,7 @@ async function cleanup(args) {
         console.log("Cleaning up interrupted test/deploy state...".bold)
 
         const cmdEnv = await getCurrentCommandEnviroment(args)
+        console.log(`  environment: ${cmdEnv.name.bold}  server: ${cmdEnv.serverStr}`)
 
         await new Listr([
             {

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -33,9 +33,9 @@ async function cleanup(args) {
 
         await new Listr([
             {
-                // Must run before "Undo env changes": stashes any env-swapped files,
-                // checks out last-deployed versions, pushes them to server, then pops
-                // the stash — mirroring the restoreChanges() + unApply order in test.js.
+                // Undoes any pending env swap first so git can see all files clearly,
+                // then stashes, checks out last-deployed versions, pushes them to server,
+                // and restores git state. The "Undo env" task below becomes a no-op.
                 title: "Restore server files to last deployed version".bold,
                 skip: () => args.localOnly ? "Skipping server restore (--localOnly)" : false,
                 task: async () => {
@@ -50,6 +50,11 @@ async function cleanup(args) {
                     if (changedFiles.length === 0) return;
 
                     console.log("\n  Restoring changed files...".yellow);
+
+                    // Undo any pending env swap first so git can properly see all files
+                    // before stashing. Files marked --assume-unchanged are invisible to
+                    // git stash, which would leave them on disk and cause checkout to fail.
+                    await cmdEnv.unApplyCurrentCommandEnvironmentChanges();
 
                     let stashed = false;
                     await git().env('LC_ALL', 'C').stash(["--include-untracked"])

--- a/lib/commands/cleanup.js
+++ b/lib/commands/cleanup.js
@@ -78,7 +78,7 @@ async function cleanup(args) {
         }
 
         console.log("\nDone!".green, "\nYou can now run 'cob-cli test' or 'cob-cli deploy' again.")
-        console.log("If files were changed during a test, run " + "cob-cli updateFromServer".yellow + " to resync.\n")
+        console.log("If files were changed during a test, a " + "cob-cli deploy -f".yellow + " with the previous version may be needed to resync.\n")
 
     } catch(err) {
         console.error("\n", err.message)

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -4,11 +4,13 @@ const { confirmExecutionOfChanges } = require("../task_lists/common_syncFiles");
 const { validateDeployConditions } = require("../task_lists/deploy_validate");
 const { executeTasks } = require("../task_lists/deploy_execute");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
+const { saveOperationState, clearOperationState } = require("../task_lists/common_operationState");
 
 async function deploy(args) {
     try {
         checkRepoVersion()
         const cmdEnv = await getCurrentCommandEnviroment(args)
+        saveOperationState(cmdEnv.name, cmdEnv.servername)
         if(args.resync) args.force = true;
 
         console.log(`Checking conditions to deploy ${cmdEnv.branchStr} to ${cmdEnv.serverStr}...` );
@@ -21,12 +23,14 @@ async function deploy(args) {
             changes = await confirmExecutionOfChanges(cmdEnv)
         } catch (err) {
             await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
+            clearOperationState()
             throw err
         }
 
         if(changes.length == 0) {
             if(!args.force) {
                 await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
+                clearOperationState()
                 throw new Error("Canceled:".yellow + " nothing todo\n")
             }
             console.log(" Just updating deploy information.")
@@ -34,9 +38,11 @@ async function deploy(args) {
 
         await executeTasks(cmdEnv, args).run();
 
+        clearOperationState()
         console.log("\nDone!".green, "\nEnjoy!")
 
     } catch(err) {
+        clearOperationState()
         console.error("\n",err.message);
     }
 }

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -6,8 +6,9 @@ const { otherFilesContiousReload } = require("../task_lists/test_otherFilesConti
 const { getCurrentCommandEnviroment } = require("../task_lists/common_enviromentHandler");
 const { getKeypress } = require("../task_lists/common_helpers");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
+const { saveOperationState, clearOperationState } = require("../task_lists/common_operationState");
 
-async function test (args) {    
+async function test (args) {
     let restoreChanges, error = "";
     let cmdEnv
     let spawned
@@ -15,6 +16,7 @@ async function test (args) {
         checkRepoVersion()
         console.log("Start testing… ")
         cmdEnv = await getCurrentCommandEnviroment(args)
+        saveOperationState(cmdEnv.name, cmdEnv.servername)
 
         if(!args.localOnly) {
             await validateTestingConditions(cmdEnv, args) 
@@ -37,6 +39,7 @@ async function test (args) {
     } finally {
         restoreChanges && await restoreChanges()
         cmdEnv && await cmdEnv.unApplyCurrentCommandEnvironmentChanges() // Repõe as configurações
+        clearOperationState()
         spawned && await spawned.stop();
         // Dá tempo aos subprocessos para morrer (acho que já não é preciso)
         setTimeout(() => {

--- a/lib/task_lists/common_enviromentHandler.js
+++ b/lib/task_lists/common_enviromentHandler.js
@@ -74,7 +74,7 @@ async function _applySpecific(environmentName) {
         if(!fs.existsSync(deleteFile)) {
             if(fs.existsSync(prodFile)) {
                 let backupFile = envSpecificFile.replace(/\.ENV__.*__/,".ENV__ORIGINAL_BACKUP__")
-                await git().raw(["update-index","--assume-unchanged", prodFile])
+                await git().raw(["update-index","--assume-unchanged", prodFile]).catch(() => {})
                 fs.renameSync(prodFile, backupFile)
             } else {
                 fs.appendFileSync('.git/info/exclude', "\n" + prodFile)
@@ -82,7 +82,7 @@ async function _applySpecific(environmentName) {
             }
         }
         fs.renameSync(envSpecificFile, prodFile)
-        await git().raw(["update-index","--assume-unchanged", envSpecificFile])
+        await git().raw(["update-index","--assume-unchanged", envSpecificFile]).catch(() => {})
     }
 }
 
@@ -94,11 +94,11 @@ async function _undoSpecific(environmentName) {
         let prodFile = changedFile.replace(/\.ENV__.*__/,"")
         let originalEnvSpecificFile = changedFile.replace(/\.ENV__.*__/,'.ENV__' + environmentName + '__')
         fs.renameSync(prodFile, originalEnvSpecificFile)
-        await git().raw(["update-index","--no-assume-unchanged", originalEnvSpecificFile])
-        
+        await git().raw(["update-index","--no-assume-unchanged", originalEnvSpecificFile]).catch(() => {})
+
         if( changedFile.indexOf("\.ENV__ORIGINAL_BACKUP__") > 0 ) {
             fs.renameSync(changedFile, prodFile)
-            await git().raw(["update-index","--no-assume-unchanged", prodFile])
+            await git().raw(["update-index","--no-assume-unchanged", prodFile]).catch(() => {})
         }
         if( changedFile.indexOf("\.ENV__DELETE__")  > 0 ) {
             flagDeleteExclude = true

--- a/lib/task_lists/common_operationState.js
+++ b/lib/task_lists/common_operationState.js
@@ -1,0 +1,16 @@
+const fs = require('fs-extra');
+const STATE_FILE = ".git/cob-cli-state";
+
+function saveOperationState(environment, servername) {
+    try { fs.writeJsonSync(STATE_FILE, { environment, servername }); } catch {}
+}
+
+function loadOperationState() {
+    try { return fs.readJsonSync(STATE_FILE); } catch { return null; }
+}
+
+function clearOperationState() {
+    try { fs.unlinkSync(STATE_FILE); } catch {}
+}
+
+module.exports = { saveOperationState, loadOperationState, clearOperationState };

--- a/lib/task_lists/test_otherFilesContiousReload.js
+++ b/lib/task_lists/test_otherFilesContiousReload.js
@@ -146,6 +146,7 @@ async function removeFileFromCurrentTest(server, changedFile) {
     await execa('ssh', [server, "sed -i '/" + changedFile.split("/").join("\\/") + "/d'  " + SERVER_IN_PROGRESS_TEST_FILE]).catch( () => {/* ignore files removed by user */} );
     console.log(" reset ".brightGreen + changedFile);
 }
+exports.removeFileFromCurrentTest = removeFileFromCurrentTest
 
 /* ************************************ */
 function checkNoTestsRunningOnServer(server) {

--- a/lib/task_lists/test_otherFilesContiousReload.js
+++ b/lib/task_lists/test_otherFilesContiousReload.js
@@ -29,22 +29,7 @@ async function otherFilesContiousReload(cmdEnv) {
     let restoreChanges = async () => {
         if(watcher.process) watcher.process.close();
         if(changedFiles.size > 0) {
-            console.log("\nRestoring changed files...".yellow);
-            let stash = true;
-            await git().env('LC_ALL', 'C').stash(["--include-untracked"]).then( value => value.indexOf("Saved") == 0 || (stash = false))
-            let lastSha = await getLastDeployedSha(cmdEnv.server)
-            await git().checkout(lastSha)
-            
-            await cmdEnv.applyLastEnvironmentDeployedToServerChanges()
-            for(let changedFile of changedFiles) {
-                await removeFileFromCurrentTest(cmdEnv.server, changedFile);
-            }
-            await cmdEnv.unApplyLastEnvironmentDeployedToServerChanges()
-
-            await execa('ssh', [cmdEnv.server,"find " + SERVER_IN_PROGRESS_TEST_FILE + " -size 0 -delete "]) //Remove file if empty
-
-            await git().checkout("-")
-            if (stash) await git().stash(["pop"])
+            await restoreServerFilesToLastDeployed(cmdEnv, changedFiles);
         }
         fs.unlinkSync("."+IN_PROGRESS_TEST_FILE)
     }
@@ -113,6 +98,35 @@ async function otherFilesContiousReload(cmdEnv) {
     return restoreChanges
 }
 exports.otherFilesContiousReload = otherFilesContiousReload
+
+/* ************************************ */
+async function restoreServerFilesToLastDeployed(cmdEnv, changedFiles) {
+    console.log("\nRestoring changed files...".yellow);
+
+    let stashed = false;
+    await git().env('LC_ALL', 'C').stash(["--include-untracked"])
+        .then(value => { stashed = value.indexOf("Saved") === 0; })
+        .catch(() => {});
+
+    const lastSha = await getLastDeployedSha(cmdEnv.server);
+    if (!lastSha) throw new Error("Cannot restore server files: no previous deploy found on server.");
+    await git().checkout(lastSha);
+
+    await cmdEnv.applyLastEnvironmentDeployedToServerChanges();
+
+    for (const changedFile of changedFiles) {
+        await removeFileFromCurrentTest(cmdEnv.server, changedFile);
+    }
+
+    await cmdEnv.unApplyLastEnvironmentDeployedToServerChanges();
+
+    await execa('ssh', [cmdEnv.server, "find " + SERVER_IN_PROGRESS_TEST_FILE + " -size 0 -delete"])
+        .catch(() => {});
+
+    await git().checkout("-");
+    if (stashed) await git().stash(["pop"]);
+}
+exports.restoreServerFilesToLastDeployed = restoreServerFilesToLastDeployed
 
 /* ************************************ */
 async function addFileToCurrentTest(server, changedFile, changedFiles, changeType, restoreChanges) {

--- a/lib/task_lists/test_otherFilesContiousReload.js
+++ b/lib/task_lists/test_otherFilesContiousReload.js
@@ -103,6 +103,12 @@ exports.otherFilesContiousReload = otherFilesContiousReload
 async function restoreServerFilesToLastDeployed(cmdEnv, changedFiles) {
     console.log("\nRestoring changed files...".yellow);
 
+    // Clean up any env-swap markers left by applyCurrentCommandEnvironmentChanges before
+    // stashing. These files are gitignored, so git stash --include-untracked ignores them.
+    // If they survive into _undoSpecific(lastEnv) they create ghost env files that are
+    // untracked at lastSha, causing "git checkout -" to abort.
+    await cmdEnv.unApplyCurrentCommandEnvironmentChanges();
+
     let stashed = false;
     await git().env('LC_ALL', 'C').stash(["--include-untracked"])
         .then(value => { stashed = value.indexOf("Saved") === 0; })


### PR DESCRIPTION
Adds `cob-cli cleanup` which undoes environment-specific file swaps,
restores a detached HEAD to the previous branch, removes local and
server test lock files, and informs the user of any pending stashes.

https://claude.ai/code/session_015ZSfgyuMz89PmEEiAkreGA