### PR TITLE
Fixes for stops

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -4,13 +4,16 @@ const { confirmExecutionOfChanges } = require("../task_lists/common_syncFiles");
 const { validateDeployConditions } = require("../task_lists/deploy_validate");
 const { executeTasks } = require("../task_lists/deploy_execute");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
-const { saveOperationState, clearOperationState } = require("../task_lists/common_operationState");
+const { saveOperationState, clearOperationState, checkNoInterruptedRun } = require("../task_lists/common_operationState");
 
 async function deploy(args) {
+    let stateSaved = false
     try {
         checkRepoVersion()
         const cmdEnv = await getCurrentCommandEnviroment(args)
+        await checkNoInterruptedRun()
         saveOperationState(cmdEnv.name, cmdEnv.servername)
+        stateSaved = true
         if(args.resync) args.force = true;
 
         console.log(`Checking conditions to deploy ${cmdEnv.branchStr} to ${cmdEnv.serverStr}...` );
@@ -23,14 +26,14 @@ async function deploy(args) {
             changes = await confirmExecutionOfChanges(cmdEnv)
         } catch (err) {
             await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
-            clearOperationState()
+            if (stateSaved) clearOperationState()
             throw err
         }
 
         if(changes.length == 0) {
             if(!args.force) {
                 await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
-                clearOperationState()
+                if (stateSaved) clearOperationState()
                 throw new Error("Canceled:".yellow + " nothing todo\n")
             }
             console.log(" Just updating deploy information.")
@@ -38,11 +41,11 @@ async function deploy(args) {
 
         await executeTasks(cmdEnv, args).run();
 
-        clearOperationState()
+        if (stateSaved) clearOperationState()
         console.log("\nDone!".green, "\nEnjoy!")
 
     } catch(err) {
-        clearOperationState()
+        if (stateSaved) clearOperationState()
         console.error("\n",err.message);
     }
 }

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -12,6 +12,13 @@ async function test (args) {
     let restoreChanges, error = "";
     let cmdEnv
     let spawned
+
+    let rejectOnSignal;
+    const signalPromise = new Promise((_, reject) => { rejectOnSignal = reject; });
+    const handleSignal = () => rejectOnSignal(new Error('signal'));
+    process.once('SIGTERM', handleSignal);
+    process.once('SIGHUP', handleSignal);
+
     try {
         checkRepoVersion()
         console.log("Start testing… ")
@@ -29,17 +36,22 @@ async function test (args) {
 
         let key;
         do {
-            key = await getKeypress()
+            key = await Promise.race([getKeypress(), signalPromise, spawned.failed]);
             if(key == "o") opn("http://localhost:8040/recordm/index.html")
-        } while( key != "q" && key != "ctrl+c" ) 
+        } while( key != "q" && key != "ctrl+c" )
 
-    } catch (err) { 
-        error = err.message
-        console.log("\n",error)
+    } catch (err) {
+        if(err.message !== 'signal' && err.message !== 'processes-failed') {
+            error = err.message
+            console.log("\n",error)
+        }
     } finally {
-        restoreChanges && await restoreChanges()
+        process.off('SIGTERM', handleSignal);
+        process.off('SIGHUP', handleSignal);
+        try { process.stdin.setRawMode(false); } catch {}
         cmdEnv && await cmdEnv.unApplyCurrentCommandEnvironmentChanges() // Repõe as configurações
         clearOperationState()
+        restoreChanges && await restoreChanges()
         spawned && await spawned.stop();
         // Dá tempo aos subprocessos para morrer (acho que já não é preciso)
         setTimeout(() => {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -6,12 +6,13 @@ const { otherFilesContiousReload } = require("../task_lists/test_otherFilesConti
 const { getCurrentCommandEnviroment } = require("../task_lists/common_enviromentHandler");
 const { getKeypress } = require("../task_lists/common_helpers");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
-const { saveOperationState, clearOperationState } = require("../task_lists/common_operationState");
+const { saveOperationState, clearOperationState, checkNoInterruptedRun } = require("../task_lists/common_operationState");
 
 async function test (args) {
     let restoreChanges, error = "";
     let cmdEnv
     let spawned
+    let stateSaved = false
 
     let rejectOnSignal;
     const signalPromise = new Promise((_, reject) => { rejectOnSignal = reject; });
@@ -23,10 +24,12 @@ async function test (args) {
         checkRepoVersion()
         console.log("Start testing… ")
         cmdEnv = await getCurrentCommandEnviroment(args)
+        await checkNoInterruptedRun()
         saveOperationState(cmdEnv.name, cmdEnv.servername)
+        stateSaved = true
 
         if(!args.localOnly) {
-            await validateTestingConditions(cmdEnv, args) 
+            await validateTestingConditions(cmdEnv, args)
             await cmdEnv.applyCurrentCommandEnvironmentChanges()
             restoreChanges = await otherFilesContiousReload(cmdEnv)
         } else {
@@ -50,8 +53,8 @@ async function test (args) {
         process.off('SIGHUP', handleSignal);
         try { process.stdin.setRawMode(false); } catch {}
         cmdEnv && await cmdEnv.unApplyCurrentCommandEnvironmentChanges() // Repõe as configurações
-        clearOperationState()
         restoreChanges && await restoreChanges()
+        if (stateSaved) clearOperationState()
         spawned && await spawned.stop();
         // Dá tempo aos subprocessos para morrer (acho que já não é preciso)
         setTimeout(() => {

--- a/lib/task_lists/common_operationState.js
+++ b/lib/task_lists/common_operationState.js
@@ -1,4 +1,5 @@
 const fs = require('fs-extra');
+const fg = require('fast-glob');
 const STATE_FILE = ".git/cob-cli-state";
 
 function saveOperationState(environment, servername) {
@@ -13,4 +14,15 @@ function clearOperationState() {
     try { fs.unlinkSync(STATE_FILE); } catch {}
 }
 
-module.exports = { saveOperationState, loadOperationState, clearOperationState };
+async function checkNoInterruptedRun() {
+    const stateExists = !!loadOperationState();
+    const envBackupFiles = await fg(['**/*.ENV__ORIGINAL_BACKUP__.*', '**/*.ENV__DELETE__.*'], { onlyFiles: false, dot: true });
+    if (stateExists || envBackupFiles.length > 0) {
+        throw new Error(
+            "\nAborted:".red + " found traces of a previous interrupted test/deploy.\n"
+            + "Run " + "cob-cli cleanup".yellow + " to restore the repo to a clean state first.\n"
+        );
+    }
+}
+
+module.exports = { saveOperationState, loadOperationState, clearOperationState, checkNoInterruptedRun };

--- a/lib/task_lists/test_customUIsContinuosReload.js
+++ b/lib/task_lists/test_customUIsContinuosReload.js
@@ -82,14 +82,19 @@ async function customUIsContinuosReload(cmdEnv, dashboard) {
         }
     }
 
-    conc.result.catch( _err => { 
+    let notifyFailure;
+    const failurePromise = new Promise((_, reject) => { notifyFailure = reject; });
+
+    conc.result.catch( _err => {
         if(isStopping) return;
 
         stopEverything();
+        notifyFailure(new Error('processes-failed'));
     });
 
     return {
-        stop: stopEverything
+        stop: stopEverything,
+        failed: failurePromise
     };
 }
 exports.customUIsContinuosReload = customUIsContinuosReload;


### PR DESCRIPTION
Introduz melhorias na forma como lida com execuções abortadas:
* para o webpack
* faz reset ao tratamento do input (estava a ficar em modo raw)
* recusa correr enquanto o repo não estiver OK