### PR TITLE
Prevent duplicate autocomplete setup and add idempotency check

### DIFF
--- a/bin/handleAutoComplete.js
+++ b/bin/handleAutoComplete.js
@@ -1,12 +1,13 @@
 const path = require('path');
+const fs = require('fs');
 
 /* Autocomplete Component*/
 var omelette = require('omelette');
 const commandStructure = {
-    'init' : [], 
-    'customize' : [], 
-    'test' : [], 
-    'deploy' : [], 
+    'init' : [],
+    'customize' : [],
+    'test' : [],
+    'deploy' : [],
     'updateFromServer' : [],
     'upgradeRepo' : []
 }
@@ -19,8 +20,22 @@ if (~process.argv.indexOf('--setup')) {
         // we exit cleanly so that postinstall completes successfuly
         process.exit(0)
     }
+    if (isAutocompleteAlreadyInstalled()) {
+        console.log("Autocomplete already set up, skipping.")
+        process.exit(0)
+    }
     console.log("Setting up...")
     completion.setupShellInitFile()
+}
+
+function isAutocompleteAlreadyInstalled() {
+    try {
+        const initFile = completion.getDefaultShellInitFile()
+        if (!initFile || !fs.existsSync(initFile)) return false
+        return fs.readFileSync(initFile, 'utf8').includes('# begin cob-cli completion')
+    } catch (e) {
+        return false
+    }
 }
 // remove from system profiles
 if (~process.argv.indexOf('--cleanup')) {


### PR DESCRIPTION
## Summary
This change adds an idempotency check to the autocomplete setup process to prevent duplicate installations and improve the user experience when running setup multiple times.

## Key Changes
- Added `fs` module import for file system operations
- Implemented `isAutocompleteAlreadyInstalled()` function that checks if autocomplete has already been configured by looking for the completion marker in the shell init file
- Added early exit logic during setup if autocomplete is already installed, with user-friendly messaging
- Fixed trailing whitespace in the `commandStructure` object definition

## Implementation Details
The new `isAutocompleteAlreadyInstalled()` function:
- Retrieves the default shell initialization file path
- Checks if the file exists before attempting to read it
- Searches for the `# begin cob-cli completion` marker string to determine if setup has already been performed
- Gracefully handles errors by returning `false`, allowing setup to proceed if the check fails
- Prevents redundant setup operations and provides clear feedback to users

This makes the setup process idempotent, allowing users to safely re-run the setup command without issues.

https://claude.ai/code/session_01AzMokeeRKoExfJsEcVh6XT