### PR TITLE
deploy/test: state interrompido como task do listr + mensagem detalhada

### DIFF
--- a/bin/cob-cli.js
+++ b/bin/cob-cli.js
@@ -74,7 +74,14 @@ program
     .option('-V --verbose', 'verbose execution of tasks', increaseVerbosity, 0)
     .option('-s --servername <servername>', 'use <servername>.cultofbits.pt (i.e. name without the FQDN)')
     .description('Deploy customization to the server')
-    .action( deploy );
+    .action( async (args) => {
+        try {
+            await deploy(args)
+        } catch (err) {
+            console.error("\n", err.message);
+            process.exitCode = 1;
+        }
+    });
 
 program
     .command('cleanup')

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -7,43 +7,39 @@ const { checkRepoVersion } = require("../commands/upgradeRepo");
 const { saveOperationState, clearOperationState } = require("../task_lists/common_operationState");
 
 async function deploy(args) {
+    checkRepoVersion()
+    const cmdEnv = await getCurrentCommandEnviroment(args)
+    if(args.resync) args.force = true;
+
+    console.log(`Checking conditions to deploy ${cmdEnv.branchStr} to ${cmdEnv.serverStr}...` );
+
+    await validateDeployConditions(cmdEnv,args).run()
+
+    saveOperationState(cmdEnv.name, cmdEnv.servername)
+
+    await cmdEnv.applyCurrentCommandEnvironmentChanges()
+    let changes = [];
     try {
-        checkRepoVersion()
-        const cmdEnv = await getCurrentCommandEnviroment(args)
-        if(args.resync) args.force = true;
+        changes = await confirmExecutionOfChanges(cmdEnv)
+    } catch (err) {
+        await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
+        clearOperationState()
+        throw err
+    }
 
-        console.log(`Checking conditions to deploy ${cmdEnv.branchStr} to ${cmdEnv.serverStr}...` );
-
-        await validateDeployConditions(cmdEnv,args).run()
-
-        saveOperationState(cmdEnv.name, cmdEnv.servername)
-
-        await cmdEnv.applyCurrentCommandEnvironmentChanges()
-        let changes = [];
-        try {
-            changes = await confirmExecutionOfChanges(cmdEnv)
-        } catch (err) {
+    if(changes.length == 0) {
+        if(!args.force) {
             await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
             clearOperationState()
-            throw err
+            console.log("\nCanceled!".yellow + " nothing todo\n")
+            return
         }
-
-        if(changes.length == 0) {
-            if(!args.force) {
-                await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
-                clearOperationState()
-                console.log("\nCanceled!".yellow + " nothing todo\n")
-                return
-            }
-            console.log(" Just updating deploy information.")
-        }
-
-        await executeTasks(cmdEnv, args).run();
-
-        clearOperationState()
-        console.log("\nDone!".green, "\nEnjoy!")
-    } catch (err) {
-        console.error("\n", err.message);
+        console.log(" Just updating deploy information.")
     }
+
+    await executeTasks(cmdEnv, args).run();
+
+    clearOperationState()
+    console.log("\nDone!".green, "\nEnjoy!")
 }
 module.exports = deploy;

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -4,25 +4,19 @@ const { confirmExecutionOfChanges } = require("../task_lists/common_syncFiles");
 const { validateDeployConditions } = require("../task_lists/deploy_validate");
 const { executeTasks } = require("../task_lists/deploy_execute");
 const { checkRepoVersion } = require("../commands/upgradeRepo");
-const { saveOperationState, clearOperationState, checkNoInterruptedRun } = require("../task_lists/common_operationState");
+const { saveOperationState, clearOperationState } = require("../task_lists/common_operationState");
 
 async function deploy(args) {
     try {
         checkRepoVersion()
         const cmdEnv = await getCurrentCommandEnviroment(args)
-        await checkNoInterruptedRun()
-        saveOperationState(cmdEnv.name, cmdEnv.servername)
         if(args.resync) args.force = true;
 
         console.log(`Checking conditions to deploy ${cmdEnv.branchStr} to ${cmdEnv.serverStr}...` );
 
-        try {
-            await validateDeployConditions(cmdEnv,args).run()
-        } catch (err) {
-            // we should clear the operation state
-            clearOperationState();
-            throw err
-        }
+        await validateDeployConditions(cmdEnv,args).run()
+
+        saveOperationState(cmdEnv.name, cmdEnv.servername)
 
         await cmdEnv.applyCurrentCommandEnvironmentChanges()
         let changes = [];

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -7,45 +7,49 @@ const { checkRepoVersion } = require("../commands/upgradeRepo");
 const { saveOperationState, clearOperationState, checkNoInterruptedRun } = require("../task_lists/common_operationState");
 
 async function deploy(args) {
-    checkRepoVersion()
-    const cmdEnv = await getCurrentCommandEnviroment(args)
-    await checkNoInterruptedRun()
-    saveOperationState(cmdEnv.name, cmdEnv.servername)
-    if(args.resync) args.force = true;
-
-    console.log(`Checking conditions to deploy ${cmdEnv.branchStr} to ${cmdEnv.serverStr}...` );
-
     try {
-        await validateDeployConditions(cmdEnv,args).run()
-    } catch (err) {
-        // we should clear the operation state
-        clearOperationState();
-        throw err
-    }
+        checkRepoVersion()
+        const cmdEnv = await getCurrentCommandEnviroment(args)
+        await checkNoInterruptedRun()
+        saveOperationState(cmdEnv.name, cmdEnv.servername)
+        if(args.resync) args.force = true;
 
-    await cmdEnv.applyCurrentCommandEnvironmentChanges()
-    let changes = [];
-    try {
-        changes = await confirmExecutionOfChanges(cmdEnv)
-    } catch (err) {
-        await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
-        clearOperationState()
-        throw err
-    }
+        console.log(`Checking conditions to deploy ${cmdEnv.branchStr} to ${cmdEnv.serverStr}...` );
 
-    if(changes.length == 0) {
-        if(!args.force) {
+        try {
+            await validateDeployConditions(cmdEnv,args).run()
+        } catch (err) {
+            // we should clear the operation state
+            clearOperationState();
+            throw err
+        }
+
+        await cmdEnv.applyCurrentCommandEnvironmentChanges()
+        let changes = [];
+        try {
+            changes = await confirmExecutionOfChanges(cmdEnv)
+        } catch (err) {
             await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
             clearOperationState()
-            console.log("\nCanceled!".yellow + " nothing todo\n")
-            return
+            throw err
         }
-        console.log(" Just updating deploy information.")
+
+        if(changes.length == 0) {
+            if(!args.force) {
+                await cmdEnv.unApplyCurrentCommandEnvironmentChanges()
+                clearOperationState()
+                console.log("\nCanceled!".yellow + " nothing todo\n")
+                return
+            }
+            console.log(" Just updating deploy information.")
+        }
+
+        await executeTasks(cmdEnv, args).run();
+
+        clearOperationState()
+        console.log("\nDone!".green, "\nEnjoy!")
+    } catch (err) {
+        console.error("\n", err.message);
     }
-
-    await executeTasks(cmdEnv, args).run();
-
-    clearOperationState()
-    console.log("\nDone!".green, "\nEnjoy!")
 }
 module.exports = deploy;

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -25,16 +25,18 @@ async function test (args) {
         checkRepoVersion()
         console.log("Start testing… ")
         cmdEnv = await getCurrentCommandEnviroment(args)
-        await checkNoInterruptedRun()
-        saveOperationState(cmdEnv.name, cmdEnv.servername)
-        stateSaved = true
 
         if(!args.localOnly) {
             await validateTestingConditions(cmdEnv, args)
+            saveOperationState(cmdEnv.name, cmdEnv.servername)
+            stateSaved = true
             await cmdEnv.applyCurrentCommandEnvironmentChanges()
             envChangesApplied = true
             restoreChanges = await otherFilesContiousReload(cmdEnv)
         } else {
+            await checkNoInterruptedRun()
+            saveOperationState(cmdEnv.name, cmdEnv.servername)
+            stateSaved = true
             await cmdEnv.applyCurrentCommandEnvironmentChanges()
             envChangesApplied = true
         }

--- a/lib/task_lists/common_operationState.js
+++ b/lib/task_lists/common_operationState.js
@@ -15,14 +15,30 @@ function clearOperationState() {
 }
 
 async function checkNoInterruptedRun() {
-    const stateExists = !!loadOperationState();
+    const savedState = loadOperationState();
     const envBackupFiles = await fg(['**/*.ENV__ORIGINAL_BACKUP__.*', '**/*.ENV__DELETE__.*'], { onlyFiles: false, dot: true });
-    if (stateExists || envBackupFiles.length > 0) {
-        throw new Error(
-            "\nAborted:".red + " found traces of a previous interrupted test/deploy.\n"
-            + "Run " + "cob-cli cleanup".yellow + " to restore the repo to a clean state first.\n"
+    if (!savedState && envBackupFiles.length === 0) return;
+
+    const details = [];
+    if (savedState) {
+        details.push(
+            "  saved state: environment " + (savedState.environment || "?").bold
+            + ", server " + (savedState.servername || "?").bold
         );
     }
+    if (envBackupFiles.length > 0) {
+        details.push("  leftover environment backup files (" + envBackupFiles.length + "):");
+        envBackupFiles.slice(0, 5).forEach(f => details.push("    " + f));
+        if (envBackupFiles.length > 5) {
+            details.push("    ... and " + (envBackupFiles.length - 5) + " more");
+        }
+    }
+
+    throw new Error(
+        "\nAborted:".red + " found traces of a previous interrupted test/deploy.\n"
+        + details.join("\n") + "\n\n"
+        + "Run " + "cob-cli cleanup".yellow + " to restore the repo to a clean state first.\n"
+    );
 }
 
 module.exports = { saveOperationState, loadOperationState, clearOperationState, checkNoInterruptedRun };

--- a/lib/task_lists/common_operationState.js
+++ b/lib/task_lists/common_operationState.js
@@ -17,28 +17,28 @@ function clearOperationState() {
 async function checkNoInterruptedRun() {
     const savedState = loadOperationState();
     const envBackupFiles = await fg(['**/*.ENV__ORIGINAL_BACKUP__.*', '**/*.ENV__DELETE__.*'], { onlyFiles: false, dot: true });
-    if (!savedState && envBackupFiles.length === 0) return;
+    if (savedState || envBackupFiles.length > 0) {
+        const details = [];
+        if (savedState) {
+            details.push(
+                "  saved state: environment " + (savedState.environment || "?").bold
+                + ", server " + (savedState.servername || "?").bold
+            );
+        }
+        if (envBackupFiles.length > 0) {
+            details.push("  leftover environment backup files (" + envBackupFiles.length + "):");
+            envBackupFiles.slice(0, 5).forEach(f => details.push("    " + f));
+            if (envBackupFiles.length > 5) {
+                details.push("    ... and " + (envBackupFiles.length - 5) + " more");
+            }
+        }
 
-    const details = [];
-    if (savedState) {
-        details.push(
-            "  saved state: environment " + (savedState.environment || "?").bold
-            + ", server " + (savedState.servername || "?").bold
+        throw new Error(
+            "Aborted:".red + " found traces of a previous interrupted test/deploy.\n"
+            + details.join("\n") + "\n\n"
+            + "Run " + "cob-cli cleanup".yellow + " to restore the repo to a clean state first."
         );
     }
-    if (envBackupFiles.length > 0) {
-        details.push("  leftover environment backup files (" + envBackupFiles.length + "):");
-        envBackupFiles.slice(0, 5).forEach(f => details.push("    " + f));
-        if (envBackupFiles.length > 5) {
-            details.push("    ... and " + (envBackupFiles.length - 5) + " more");
-        }
-    }
-
-    throw new Error(
-        "Aborted:".red + " found traces of a previous interrupted test/deploy.\n"
-        + details.join("\n") + "\n\n"
-        + "Run " + "cob-cli cleanup".yellow + " to restore the repo to a clean state first."
-    );
 }
 
 module.exports = { saveOperationState, loadOperationState, clearOperationState, checkNoInterruptedRun };

--- a/lib/task_lists/common_operationState.js
+++ b/lib/task_lists/common_operationState.js
@@ -35,9 +35,9 @@ async function checkNoInterruptedRun() {
     }
 
     throw new Error(
-        "\nAborted:".red + " found traces of a previous interrupted test/deploy.\n"
+        "Aborted:".red + " found traces of a previous interrupted test/deploy.\n"
         + details.join("\n") + "\n\n"
-        + "Run " + "cob-cli cleanup".yellow + " to restore the repo to a clean state first.\n"
+        + "Run " + "cob-cli cleanup".yellow + " to restore the repo to a clean state first."
     );
 }
 

--- a/lib/task_lists/common_syncFiles.js
+++ b/lib/task_lists/common_syncFiles.js
@@ -175,7 +175,7 @@ function resolveCobPath(server, type, product) {
         case "serverLive":
             switch (product) {
                 case "public":
-                    return server + ":/usr/share/cob/"
+                    return getServerAddress(server) + ":/usr/share/cob/"
                 case "recordm-importer":
                 case "others":
                     return getServerAddress(server) + ':' + "/opt/" + product + "/";

--- a/lib/task_lists/deploy_validate.js
+++ b/lib/task_lists/deploy_validate.js
@@ -7,10 +7,12 @@ const { checkWorkingCopyCleanliness, checkConnectivity } = require("./common_hel
 const { getCurrentBranch, getLastDeployedSha } = require("./common_releaseManager");
 const { testEquality } = require("./common_syncFiles");
 const { checkNoTestsRunningOnServer } = require("./test_otherFilesContiousReload")
+const { checkNoInterruptedRun } = require("./common_operationState");
 
 
 function validateDeployConditions(cmdEnv, args) {
     return new Listr([
+        {   title: "Check no previous interrupted run".bold,                                                            task: ()     => checkNoInterruptedRun() },
         {   title: "Check connectivity and permissions".bold,                                                           task: ()     => checkConnectivity(cmdEnv.server) },
         {   title: "Check git status".bold,                                                                             task: ()     => checkWorkingCopyCleanliness(false) }, 
         {   title: "Check there's no 'cob-cli test' running on server".bold,                                            task: ()     => checkNoTestsRunningOnServer(cmdEnv.server) },

--- a/lib/task_lists/test_validate.js
+++ b/lib/task_lists/test_validate.js
@@ -10,11 +10,13 @@ const { getCurrentBranch, getLastDeployedSha } = require("./common_releaseManage
 const { testEquality } = require("./common_syncFiles");
 const { SERVER_IN_PROGRESS_TEST_FILE } = require("../task_lists/test_otherFilesContiousReload");
 const { getSshArgs } = require("./common_helpers");
+const { checkNoInterruptedRun } = require("./common_operationState");
 
 
 async function validateTestingConditions(cmdEnv, args) {
     console.log("Checking test conditions for", cmdEnv.serverStr );
     let result = await new Listr([
+            {   title: "Check no previous interrupted run".bold,                           task: ()     => checkNoInterruptedRun() },
             {   title: "Check connectivity and permissions".bold,                          task: ()     => checkConnectivity(cmdEnv.server) },
             {   title: "Check there's no other 'cob-cli test' running locally".bold,       task: ()     => _checkNoTestsRunningLocally() },
             {   title: "find out branch-for-HEAD",                                         task: (ctx)  => getCurrentBranch().then( currentBranch => ctx.currentBranch = currentBranch) },


### PR DESCRIPTION
## Contexto

Quando `cob-cli deploy` (ou `test`) deteta traces de uma execução anterior interrompida — ficheiro `.git/cob-cli-state` ou ficheiros `*.ENV__ORIGINAL_BACKUP__.*` / `*.ENV__DELETE__.*` — falhava com três problemas de UX:

1. O erro saía como stack trace cru do Node em vez da mensagem limpa que o resto da CLI mostra (regressão introduzida em `a72217b`).
2. A mensagem dizia apenas "found traces of a previous interrupted test/deploy" sem dar pistas concretas sobre o que tinha sido detetado.
3. O erro aparecia *antes* da lista de checks do listr, partindo o alinhamento visual com os outros erros de validação (`Unclean working tree`, etc.).

A correr `deploy.test.js` (de `cob/cob-cli-tests`, branch `claude/intelligent-einstein-5fjxe`) contra este branch apareceram duas regressões adicionais:

1. `resolveCobPath` para o produto `public` usava `server` em vez de `getServerAddress(server)`, perdendo o prefixo `COB_SSH_USER@` no destino do rsync para `/usr/share/cob/`. Em ambientes onde o user local é diferente do user remoto, o rsync caía em password prompt e falhava.
2. Uma tentativa inicial de evitar o stack trace (#1) foi feita dentro de `deploy()` com um outer `try/catch` que apenas logava `err.message`. Isso partia a API programática — testes que esperavam `await deploy(args)` rejeitar passavam a resolver, e tudo o que seguia em cascata também era afetado.

## O que mudou

- **`common_operationState.js`:** `checkNoInterruptedRun()` passa a listar na mensagem o environment/server do state guardado e até 5 ficheiros de backup órfãos (com `... and N more` se forem mais).
- **`deploy_validate.js` / `test_validate.js`:** `checkNoInterruptedRun` passou a ser a primeira task do Listr, pelo que o erro é renderizado como `✖ Check no previous interrupted run` no formato dos restantes checks.
- **`deploy.js` / `test.js`:** `saveOperationState` foi movido para *depois* do listr de validação passar, evitando sobrescrever o state pré-existente quando o check falha. Em `test --localOnly` (sem listr) mantém-se a chamada direta a `checkNoInterruptedRun`.
- **`deploy.js`:** propaga erros normalmente. O inner catch em volta de `confirmExecutionOfChanges` mantém-se (faz cleanup específico antes de re-lançar).
- **`bin/cob-cli.js`:** a `.action()` do `deploy` faz o catch amigável aqui (`console.error("\n", err.message); process.exitCode = 1`), preservando o output limpo da CLI sem alterar a API exportada.
- **`common_syncFiles.js`:** `resolveCobPath` para `public` usa `getServerAddress(server)`, alinhando com os outros cases (`recordm-importer`, `others`, default) que já usavam.

## Antes / Depois

**Antes:**
```
% cob-cli deploy
/.../common_operationState.js:21
        throw new Error(
              ^
Error:
Aborted: found traces of a previous interrupted test/deploy.
Run cob-cli cleanup to restore the repo to a clean state first.
    at checkNoInterruptedRun (...)
    at async Command.deploy (...)
Node.js v24.14.1
```

**Depois:**
```
% cob-cli deploy
Checking conditions to deploy master to dogfooding.cultofbits.pt...
  ✖ Check no previous interrupted run
    → Aborted: found traces of a previous interrupted test/deploy.
      saved state: environment master, server dogfooding.cultofbits.pt
      leftover environment backup files (10):
        authm/application.ENV__ORIGINAL_BACKUP__.properties
        recordm-importer/recordm-importer.ENV__ORIGINAL_BACKUP__.properties
        ...
        ... and 5 more

      Run cob-cli cleanup to restore the repo to a clean state first.
% echo $?
1
```

## Test plan

- [ ] `cob-cli deploy` com `.git/cob-cli-state` à mão → ✖ no listr, env/server na mensagem, `$? == 1`
- [ ] `cob-cli deploy` com ficheiros `*.ENV__ORIGINAL_BACKUP__.*` → ✖ no listr, lista de ficheiros (até 5)
- [ ] `cob-cli deploy` com working tree sujo → ✔ no check de interrupted run, ✖ em `Check git status` (regressão zero)
- [ ] `cob-cli deploy` caminho feliz → todos ✔, `clearOperationState` no fim
- [ ] `cob-cli test` com state interrompido → ✖ no listr de `validateTestingConditions`
- [ ] `cob-cli test --localOnly` com state interrompido → mensagem direta (sem listr neste ramo)
- [ ] `deploy.test.js` (cob-cli-tests `claude/intelligent-einstein-5fjxe`): `cobdeploy1 --force initializes server`, `cobdeploy2 can deploy after cobdeploy1`, `deploys env specific file`, `deploy fails on dirty working tree` (rejeita), `deploy doesnt throw on no changes` (valida o ramo no-changes real)